### PR TITLE
fix : kakao signup nickname check error fix

### DIFF
--- a/src/pages/auth/SignUp/UserSignUp/KaKaoUserSignUp.jsx
+++ b/src/pages/auth/SignUp/UserSignUp/KaKaoUserSignUp.jsx
@@ -6,6 +6,7 @@ import {
   clearEmailCheck,
   clearLoginIdCheck,
   clearNicknameCheck,
+  checkNickName,
 } from '@/store/authSlice';
 import { clearSMSAuth } from '@/store/smsAuthSlice';
 import ProfileSection from './components/signup/ProfileSection';


### PR DESCRIPTION
## 📝 PR 요약

카카오 signup 닉네임 중복검사 안됨 수정
---

## 🔧 작업 내용 상세

- 

## 🔍 테스트 및 확인 사항

- 

---

## 🧪 변경사항 관련 이슈

(예시 : `관련 이슈 : #123` 등)

-

---
