### PR TITLE
fix : user info page default profile image setted in front

### DIFF
--- a/src/pages/user/Info/component/ProfileImage.jsx
+++ b/src/pages/user/Info/component/ProfileImage.jsx
@@ -32,7 +32,7 @@ function ProfileImage() {
 
   return (
     <>
-      <img src={userInfo?.photo} alt="프로필 사진" />
+      <img src="/photodefault.svg" alt="프로필사진" />
       <input
         type="file"
         style={{ display: 'none' }}


### PR DESCRIPTION
## 📝 PR 요약

사용자 회원 정보 조회 페이지 프로필 기본 이미지 수정 > 퍼블릭 이미지 사용
---

## 🔧 작업 내용 상세

- 

## 🔍 테스트 및 확인 사항

- 

---

## 🧪 변경사항 관련 이슈

(예시 : `관련 이슈 : #123` 등)

-

---
